### PR TITLE
Update GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,7 +4,7 @@ MAKEFLAGS += --no-builtin-variables --no-builtin-rules
 
 CC := cc
 LD := ld
-CFLAGS := -Wall -Wextra -Wpedantic -Wno-unused-function -Wno-unused-parameter -Wno-unknown-attributes -Os -fno-stack-protector
+CFLAGS := -Wall -Wextra -Wpedantic -Wno-unused-function -Wno-unused-parameter -Wno-unknown-attributes -Os
 ifdef TARGET
   ifndef UAPI
     $(error UAPI must be defined when cross compiling)
@@ -90,7 +90,7 @@ flags.executable = $(flags.common) $(flags.whole_program) $(flags.use_ld) -Wl,-e
 
 # Disable strict aliasing and assume two's complement integers
 # even if CFLAGS contains options that affect this such as -O3
-CFLAGS += -fno-strict-aliasing -fwrapv
+CFLAGS += -fno-strict-aliasing -fwrapv -fno-stack-protector
 
 $(directories.build.objects)/%.o: $(directories.source)/%.c | directories
 	$(strip $(CC) $(flags.object) $(CFLAGS) -o $@ -c $<)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,8 +4,7 @@ MAKEFLAGS += --no-builtin-variables --no-builtin-rules
 
 CC := cc
 LD := ld
-CFLAGS := -Wall -Wextra -Wpedantic -Wno-unused-function -Wno-unused-parameter -Wno-unknown-attributes -Os
-
+CFLAGS := -Wall -Wextra -Wpedantic -Wno-unused-function -Wno-unused-parameter -Wno-unknown-attributes -Os -fno-stack-protector
 ifdef TARGET
   ifndef UAPI
     $(error UAPI must be defined when cross compiling)


### PR DESCRIPTION
Fix undefined reference to `__stack_chk_fail' when building. 

Platform: `Linux P14S 6.6.10-arch1-1 #1 SMP PREEMPT_DYNAMIC Fri, 05 Jan 2024 16:20:41 +0000 x86_64 GNU/Linux`

Apologies if a PR is unwarranted.
 

